### PR TITLE
Implement modern React & create CloudCannon Context and Custom Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # CloudCannon React Connector
 
-
-
 [![npm version](https://img.shields.io/npm/v/@cloudcannon/react-connector.svg)](https://www.npmjs.org/package/@cloudcannon/react-connector)
 [![install size](https://packagephobia.now.sh/badge?p=@cloudcannon/react-connector)](https://packagephobia.now.sh/result?p=@cloudcannon/react-connector)
 [![npm downloads](https://img.shields.io/npm/dm/@cloudcannon/react-connector.svg)](http://npm-stat.com/charts.html?package=@cloudcannon/react-connector)
@@ -14,28 +12,71 @@ Using a React based SSG? Want to see give your editors a live visual editing exp
 npm i @cloudcannon/react-connector
 ```
 
-## Next JS Integration
+## Next JS APP-router Integration
 
-Update the code in `pages/_app.jsx` from:
+Include the CloudCannonProvider in `app/layout.jsx`:
 
 ```
-export default function App({ Component, pageProps }) {
-	return <Component {...pageProps} />
+import { CloudCannonProvider } from "@cloudcannon/react-connector"
+
+export default function RootLayout({
+  children,
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <CloudCannonProvider>
+          {children}
+        </CloudCannonProvider>
+      </body>
+    </html>
+  )
+}
+
+```
+
+Create a client component for rendering content using the React connector and it's useCloudCannon hook. For example:
+
+```
+"use client"
+
+import { useEffect, useState } from "react"
+import { useCloudCannon } from "@cloudcannon/react-connector"
+
+import Blocks from "@/components/content-blocks"
+
+export const PageContent = ({ content }) => {
+  const { pageData } = useCloudCannon()
+  const [localContentBlocks, setLocalContentBlocks] = useState(
+    content.content_blocks
+  )
+
+  useEffect(() => {
+    if (pageData?.content_blocks) {
+      setLocalContentBlocks(pageData.content_blocks)
+    }
+  }, [pageData])
+
+  return (
+    <main className="">
+      <Blocks content_blocks={localContentBlocks} />
+    </main>
+  )
+}
+
+```
+
+And use it in your NextJs app-router pages:
+
+```
+export default async function Page({ params }) {
+  const page = await getDocFromParams(params)
+
+  return <PageContent content={doc} />
 }
 ```
 
-to:
-
-```
-import { CloudCannonConnect } from '@cloudcannon/react-connector'
-
-export default function App({ Component, pageProps }) {
-	const AppComponent = CloudCannonConnect(Component);
-	return <AppComponent {...pageProps}/>
-}
-```
-
-In CloudCannon will now push through new page props from your editors updates. 
+In CloudCannon will now push through new page props from your editors updates.
 
 ### CloudCannon options
 
@@ -46,31 +87,19 @@ to false, this will prevent any double processing conflicts.
 ```
 import { CloudCannonConnect } from '@cloudcannon/react-connector'
 
-export default function App({ Component, pageProps }) {
-	const AppComponent = CloudCannonConnect(Component, {
-		valueOptions: {
-			keepMarkdownAsHTML: false,
-			preferBlobs: true
-		}
-	});
-	return <AppComponent {...pageProps}/>
-}
-```
-### Modifying the props
-
-If your props are modified in the `getStaticProps` function you can mirror those same operations. Below is an example of 
-the `processProps` function which is passed the props before it is injected into the new props. This defaults to an identity
-function which passes the props directly through.
-
-```
-import { CloudCannonConnect } from '@cloudcannon/react-connector'
-
-export default function App({ Component, pageProps }) {
-	const AppComponent = CloudCannonConnect(Component, {
-		processProps: (props) => {
-			return props;
-		}
-	});
-	return <AppComponent {...pageProps}/>
+export default function RootLayout({
+  children,
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <CloudCannonProvider options={{
+					valueOptions: { keepMarkdownAsHTML: false, preferBlobs: true },
+          }}>
+          {children}
+        </CloudCannonProvider>
+      </body>
+    </html>
+  )
 }
 ```

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ And use it in your NextJs app-router pages:
 
 ```
 export default async function Page({ params }) {
-  const page = await getDocFromParams(params)
+  const page = await getPageFromParams(params)
 
-  return <PageContent content={doc} />
+  return <PageContent content={page} />
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-	"name": "@cloudcannon/react-connector",
-	"version": "2.0.0",
-	"description": "A React connector for activating live visual editing in CloudCannon",
-	"main": "index.js",
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 0"
-	},
-	"files": [
-		"index.js"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/CloudCannon/react-connector.git"
-	},
-	"keywords": [
-		"CloudCannon",
-		"React",
-		"NextJS",
-		"Gatsby",
-		"CMS"
-	],
-	"author": "CloudCannon",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/CloudCannon/react-connector/issues"
-	},
-	"homepage": "https://github.com/CloudCannon/react-connector#readme",
-	"dependencies": {
-		"react": "^17.0.2"
-	}
+  "name": "@cloudcannon/react-connector",
+  "version": "3.0.0",
+  "description": "A React connector for activating live visual editing in CloudCannon",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 0"
+  },
+  "files": [
+    "index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CloudCannon/react-connector.git"
+  },
+  "keywords": [
+    "CloudCannon",
+    "React",
+    "NextJS",
+    "Gatsby",
+    "CMS"
+  ],
+  "author": "CloudCannon",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/CloudCannon/react-connector/issues"
+  },
+  "homepage": "https://github.com/CloudCannon/react-connector#readme",
+  "dependencies": {
+    "react": "^17.0.2"
+  }
 }


### PR DESCRIPTION
This is an idea for a rewrite for the react-connector using modern React syntax and a use example with NextJS 13's app-router. It uses a CloudCannonProvider and useCloudCannon hook for fetching the pageData while live editing in CloudCannon. More details in the updated README.